### PR TITLE
Fix typo and add wait time for DB when `make install`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ RAKE = docker-compose run app bundle exec rake
 RUN = docker-compose run app
 
 install:
-	@make secert
+	@make secret
 	@touch app.local.env
 	@$(RUN) bundle install --retry=3 --jobs=2
 	@$(RUN) bundle exec rails db:create
@@ -11,7 +11,7 @@ install:
 	@$(RUN) bundle exec rails assets:precompile RAILS_ENV=production
 	@make reindex
 update:
-	@make secert
+	@make secret
 	@touch app.local.env
 	@$(RUN) bundle exec rails db:migrate
 	@$(RUN) bundle exec rails assets:precompile RAILS_ENV=production
@@ -33,7 +33,7 @@ reindex:
 	@$(RAKE) environment elasticsearch:import:model CLASS=Topic FORCE=y
 	@$(RAKE) environment elasticsearch:import:model CLASS=Page FORCE=y
 	@$(RAKE) environment elasticsearch:import:model CLASS=User FORCE=y
-secert:
+secret:
 	@test -f app.secret.env || echo "secret_key_base=`openssl rand -hex 32`" > app.secret.env
 	@cat app.secret.env
 start-brew-services:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ install:
 	@make secret
 	@touch app.local.env
 	@$(RUN) bundle install --retry=3 --jobs=2
+	@echo "\n**Notice**: Wait for the initialization of DB...\n"
+	@echo "...\n"
+	@sleep 10
 	@$(RUN) bundle exec rails db:create
 	@$(RUN) bundle exec rails db:migrate
 	@$(RUN) bundle exec rails db:seed


### PR DESCRIPTION
In `make install `, when run
```shell
@$(RUN) bundle install --retry=3 --jobs=2
```

the DB will begin to initialize, but if DB can't finish initialization when continue to run
```shell
@$(RUN) bundle exec rails db:create
```

there will be a error like failed to connect DB (here I use MySQL, so the error is about MySQL)
```shell 
Mysql2::Error: Can't create database 'cloudeda_production' (errno: 15183808): CREATE DATABASE `cloudeda_production` DEFAULT CHARACTER SET `utf8` COLLATE `utf8_unicode_ci`
/usr/local/bundle/gems/mysql2-0.4.4/lib/mysql2/client.rb:107:in `_query'
/usr/local/bundle/gems/mysql2-0.4.4/lib/mysql2/client.rb:107:in `block in query'
/usr/local/bundle/gems/mysql2-0.4.4/lib/mysql2/client.rb:106:in `handle_interrupt'
/usr/local/bundle/gems/mysql2-0.4.4/lib/mysql2/client.rb:106:in `query'
/usr/local/bundle/gems/activerecord-4.2.5/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:305:in `block in execute'
...
```

So, we can give some message, and wait for some time before `bundle exec rails db:create`.

