### PR TITLE
支持配置非80端口访问

### DIFF
--- a/etc/nginx/homeland.conf
+++ b/etc/nginx/homeland.conf
@@ -137,9 +137,9 @@ server {
   # DO NOT CHANGE THIS
   location / {
     proxy_redirect     off;
-    proxy_set_header   Host $host;
-    proxy_set_header   X-Forwarded-Host $host;
-    proxy_set_header   X-Forwarded-Server $host;
+    proxy_set_header   Host $http_host;
+    proxy_set_header   X-Forwarded-Host $http_host;
+    proxy_set_header   X-Forwarded-Server $http_host;
     proxy_set_header   X-Real-IP        $remote_addr;
     proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
     proxy_buffering    on;


### PR DESCRIPTION
当访问`非80`端口时，遇到需要重定向的页面会从定向到`80`端口。
将 Nginx 的配置中 `$host` 改为 `$http_host` 可以解决这个问题。