### PR TITLE
Update app.default.env. Add comments that upload_provider can be file.

### DIFF
--- a/app.default.env
+++ b/app.default.env
@@ -64,7 +64,7 @@ sso.url=
 sso.secret=
 
 # [Upload Config]
-# can be  upyun/aliyun
+# can be  upyun/aliyun/file
 # http://gethomeland.com/docs/configuration/upload/
 upload_provider=file
 upload_access_id=


### PR DESCRIPTION
虽然默认值写的是file，但如果在注释中不注明可以有file，当用户直接修改为如aliyun时，结果测试没有成功后，再改回头时，可能会把这些行(包括“upload_provider=”这一行)都注释掉，导致图片无法上传到本地目录。而且这时用户如果不仔细，是不会去检查原始app.default.env文件原来是可以设置成file的。我遇到了这个问题后，在读homeland-docker的原始app.default.env后才发现要显式设置为file.