### PR TITLE
Upgrading elasticsearch from 2.4.1 to 5.3.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ memcached:
     - '11211'
 
 elasticsearch:
-  image: elasticsearch:2.4.1
+  image: elasticsearch:5.3.0
   volumes:
     - ./data/elasticsearch:/usr/share/elasticsearch/data
   ports:


### PR DESCRIPTION
当`sudo make reindex`时，报错如下:
`{"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"No handler for type [text] declared on field [title]"}]`

> text 格式在 elasticsearch 5.x 才被支持，而homeland-docker部署包中，elasticsearch的版本是 2.4.1。