### PR TITLE
部分切换至 alpine.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 postgresql:
   container_name: 'homeland_postgresql'
-  image: postgres:9.5
+  image: postgres:9.5-alpine
   ports:
     - '5432'
   volumes:
@@ -8,7 +8,7 @@ postgresql:
 
 redis:
   container_name: 'homeland_redis'
-  image: redis:3.2.7
+  image: redis:3.2.7-alpine
   mem_limit: 300m
   ports:
     - '6379'
@@ -17,14 +17,14 @@ redis:
 
 memcached:
   container_name: 'homeland_memcached'
-  image: memcached:1.4.31
+  image: memcached:1.4.31-alpine
   mem_limit: 256m
   ports:
     - '11211'
 
 elasticsearch:
   container_name: 'homeland_elasticsearch'
-  image: elasticsearch:5
+  image: elasticsearch:5-alpine
   environment:
     - bootstrap.memory_lock=true
     - "ES_JAVA_OPTS=-Xms256m -Xmx512m"


### PR DESCRIPTION
| REPOSITORY  | TAG  | IMAGE ID  | CREATED  | SIZE  |
|---|---|---|---|---|
| postgres  | 9.5-alpine  | f5ea5adbadc8  |  7 weeks ago | 36.9MB  |
| redis  |  3.2.7-alpine  | 147b1b8460d2  | 6 months ago  | 22.1MB  |
| memcached  | 1.4.31-alpine  | b0d4b9d95193  | 10 months ago  | 5.89MB  |
| elasticsearch  | 5-alpine  | ddf7ded3d7a7  | 7 days ago  | 123MB  |

后续我会把 base 和 homeland 也切换到 alpine.